### PR TITLE
Some URL updates for SimProcTC and RSPIM

### DIFF
--- a/download-items/RSPSIM.md
+++ b/download-items/RSPSIM.md
@@ -11,16 +11,16 @@ category: models
 years-active: 2004-
 tags: featured model framework omnetpp5 omnetpp6
 keywords: rserpool, asap, enrp, calcapp
-download-page-url: https://www.uni-due.de/~be0001/rserpool/#Simulation
+download-page-url: https://www.nntb.no/~dreibh/rserpool/#Simulation
 github-url: https://github.com/dreibh/rspsim
-website-url: https://www.uni-due.de/~be0001/rserpool/
+website-url: https://www.nntb.no/~dreibh/rserpool/
 opp-env-command: opp_env install rspsim-latest
 ---
 
 RSPSIM (Reliable Server Pooling Simulation) is the Open Source simulation model of the IETF Reliable Server Pooling (RSerPool) architecture, a novel framework for pool and session management. The Reliable Server Pooling (RSerPool) architecture (defined by RFC 5351 to RFC 5356) is an overlay network framework to provide server replication and session failover capabilities to its applications. Server redundancy leads to load distribution and load balancing, which are also covered by RSerPool. But in strong contrast to other solutions in the area of cloud and high-performance computing, the fundamental property of RSerPool is to be "lightweight", i.e. it can also be used on devices providing only meagre memory and CPU resources (e.g. embedded systems like telecommunications equipment or routers).
 
-A detailed introduction to the model can be found in T. Dreibholz, "[Reliable Server Pooling -- Evaluation, Optimization and Extension of a Novel IETF Architecture](https://duepublico2.uni-due.de/receive/duepublico_mods_00014969)".
+A detailed introduction to the model can be found in Chapter&nbsp;6 of T.&nbsp;Dreibholz, "[Reliable Server Pooling -- Evaluation, Optimization and Extension of a Novel IETF Architecture](https://duepublico2.uni-due.de/servlets/MCRFileNodeServlet/duepublico_derivate_00016326/Dre2006_final.pdf#chapter.6)".
 
 RSPSIM had originally been started as a project at the [Institute for Experimental Mathematics](https://www.uni-due.de/mathematik/iem_en.php) of the [University of Duisburg-Essen](https://www.uni-due.de/en/index.php) in Essen, Germany. It is now maintained at the [Simula Research Laboratory](https://www.simula.no/) in Oslo, Norway.
 
-Author: [Thomas Dreibholz](https://www.uni-due.de/~be0001/), [Simula Research Laboratory](https://www.simula.no/)
+Author: [Thomas Dreibholz](https://www.nntb.no/~dreibh/), [Simula Research Laboratory](https://www.simula.no/)

--- a/download-items/SimProcTC.md
+++ b/download-items/SimProcTC.md
@@ -19,6 +19,6 @@ opp-env-command: opp_env install simproctc-latest
 
 The Simulation Processing Tool-Chain&nbsp;(SimProcTC) is a model-independent, flexible tool-chain for the setup, parallel run execution, results aggregation and data analysis for OMNeT++. It is based on [GNU R](https://www.r-project.org/) and [Reliable Server Pooling (RSerPool)](https://www.nntb.no/~dreibh/rserpool/).
 
-A detailed description of SimProcTC can be found in Appendix&nbsp;B of "[Evaluation and Optimisation of Multi-Path Transport using the Stream Control Transmission Protocol](https://duepublico2.uni-due.de/servlets/MCRFileNodeServlet/duepublico_derivate_00029737/Dre2012_final.pdf#appendix.B)".
+A detailed description of SimProcTC can be found in Appendix&nbsp;B of T.&nbsp;Dreibholz, "[Evaluation and Optimisation of Multi-Path Transport using the Stream Control Transmission Protocol](https://duepublico2.uni-due.de/servlets/MCRFileNodeServlet/duepublico_derivate_00029737/Dre2012_final.pdf#appendix.B)".
 
 Author: [Thomas Dreibholz](https://www.nntb.no/~dreibh/), [Simula Research Laboratory](https://www.simula.no/)

--- a/download-items/SimProcTC.md
+++ b/download-items/SimProcTC.md
@@ -11,14 +11,14 @@ sortkey: "08"
 category: tools
 tags: featured tool omnetpp3 omnetpp4 omnetpp5 omnetpp6
 keywords: cluster computing, simulation campaign, batch run, statistics
-download-page-url: https://www.uni-due.de/~be0001/omnetpp/#Download
+download-page-url: https://www.nntb.no/~dreibh/omnetpp/#Download
 github-url: https://github.com/dreibh/simproctc
-website-url: https://www.uni-due.de/~be0001/omnetpp/
+website-url: https://www.nntb.no/~dreibh/omnetpp/
 opp-env-command: opp_env install simproctc-latest
 ---
 
-The Simulation Processing Tool-Chain&nbsp;(SimProcTC) is a model-independent, flexible tool-chain for the setup, parallel run execution, results aggregation and data analysis for OMNeT++. It is based on [GNU R](https://www.r-project.org/) and [Reliable Server Pooling (RSerPool)](https://www.uni-due.de/~be0001/rserpool/).
+The Simulation Processing Tool-Chain&nbsp;(SimProcTC) is a model-independent, flexible tool-chain for the setup, parallel run execution, results aggregation and data analysis for OMNeT++. It is based on [GNU R](https://www.r-project.org/) and [Reliable Server Pooling (RSerPool)](https://www.nntb.no/~dreibh/rserpool/).
 
-A detailed description of SimProcTC can be found in Appendix&nbsp;B of "[Evaluation and Optimisation of Multi-Path Transport using the Stream Control Transmission Protocol](https://duepublico2.uni-due.de/servlets/MCRFileNodeServlet/duepublico_derivate_00029737/Dre2012_final.pdf)".
+A detailed description of SimProcTC can be found in Appendix&nbsp;B of "[Evaluation and Optimisation of Multi-Path Transport using the Stream Control Transmission Protocol](https://duepublico2.uni-due.de/servlets/MCRFileNodeServlet/duepublico_derivate_00029737/Dre2012_final.pdf#appendix.B)".
 
-Author: [Thomas Dreibholz](https://www.uni-due.de/~be0001/), [Simula Research Laboratory](https://www.simula.no/)
+Author: [Thomas Dreibholz](https://www.nntb.no/~dreibh/), [Simula Research Laboratory](https://www.simula.no/)


### PR DESCRIPTION
Some of the URLs for the SimProcTC tools and the RSPSIM model have changed over time. This pull request updates them to the up-to-date locations.